### PR TITLE
Fix error on maps without props

### DIFF
--- a/CoffeeCup/lua/autorun/sh_coffeecup.lua
+++ b/CoffeeCup/lua/autorun/sh_coffeecup.lua
@@ -22,7 +22,7 @@ CoffeeCup.Models = {
 if SERVER then
 function CoffeeCup.CheckRequirements()
 	
-	if CoffeeCup.ReplacementTypes then
+	if CoffeeCup.ReplacementTypes and #CoffeeCup.ReplacementTypes > 0 then
 		CoffeeCup.EntityType = table.Random(CoffeeCup.ReplacementTypes)
 		CoffeeCup.PropToReplace = table.Random(ents.FindByClass(CoffeeCup.EntityType))
 		if not CoffeeCup.PropToReplace then


### PR DESCRIPTION
Some maps (minecraft maps, for example) don't have prop_physics\* or prop_dynamic entities, so an error occurs on the TTTBeginRound hook breaking some addons, my damagelogs for example.
